### PR TITLE
Tc sig env merging

### DIFF
--- a/src/Compiler/Driver/ParseAndCheckInputs.fs
+++ b/src/Compiler/Driver/ParseAndCheckInputs.fs
@@ -1470,6 +1470,8 @@ let CheckOneInputAux'
                     // printfn $"Applying Sig {file.FileName}"
                     let fsiPartialResult, tcState =
                         let rootSigs = Zmap.add qualNameOfFile sigFileType tcState.tcsRootSigs
+                        let tcSigEnv =
+                            AddLocalRootModuleOrNamespace TcResultsSink.NoSink tcGlobals amap m tcState.tcsTcSigEnv sigFileType
 
                         // Add the signature to the signature env (unless it had an explicit signature)
                         let ccuSigForFile = CombineCcuContentFragments [ sigFileType; tcState.tcsCcuSig ]
@@ -1478,8 +1480,7 @@ let CheckOneInputAux'
                         
                         let tcState =
                             { tcState with
-                                tcsTcSigEnv = tcEnv
-                                tcsTcImplEnv = tcState.tcsTcImplEnv
+                                tcsTcSigEnv = tcSigEnv
                                 tcsRootSigs = rootSigs
                                 tcsCreatesGeneratedProvidedTypes = tcState.tcsCreatesGeneratedProvidedTypes || createsGeneratedProvidedTypes
                             }

--- a/tests/ParallelTypeCheckingTests/Code/DependencyResolution.fs
+++ b/tests/ParallelTypeCheckingTests/Code/DependencyResolution.fs
@@ -147,11 +147,7 @@ module internal DependencyResolution =
                 |> Array.exists (function Abbreviation.ModuleAbbreviation -> true | _ -> false))
             
         let trie = buildTrie nodes
-        
-        let fsiFiles =
-            nodes
-            |> Array.filter (fun f -> match f.File.AST with | ASTOrFsix.AST (ParsedInput.SigFile _) -> true | _ -> false)
-        
+
         let processFile (node : FileData) =
             let deps =
                 let fsiDep =
@@ -229,13 +225,6 @@ module internal DependencyResolution =
                     moduleRefs
                     |> Array.iter processRef
                     
-                    // Force .fsi files to depend on all other (previous) .fsi files - avoids the issue of TcEnv being overriden  
-                    let additionalFsiDeps =
-                        if node.File.Name.EndsWith ".fsi" then
-                            nodes
-                        else
-                            [||]
-                    
                     // Collect files from all reachable TrieNodes
                     let deps =
                         reachable
@@ -243,7 +232,6 @@ module internal DependencyResolution =
                         // Assume that this file depends on all files that have any module abbreviations - this is probably unnecessary.
                         // TODO Handle module abbreviations in a better way
                         |> Seq.append filesWithModuleAbbreviations
-                        |> Seq.append additionalFsiDeps
                         |> Seq.append fsiDep
                         |> Seq.map (fun f -> f.File)
                         |> Seq.toArray

--- a/tests/ParallelTypeCheckingTests/Tests/TestCompilation.fs
+++ b/tests/ParallelTypeCheckingTests/Tests/TestCompilation.fs
@@ -115,12 +115,71 @@ open A
 """
         ] |> FProject.Make  CompileOutput.Library
     
+    let dependentSignatures =
+        [
+            "A.fsi", """
+module A
+
+type AType = class end
+"""
+            "A.fs", """
+module A
+
+type AType = class end
+"""
+            "B.fsi", """
+module B
+
+open A
+
+val b: AType -> unit
+"""
+            "B.fs", """
+module B
+
+open A
+
+let b (a:AType) = ()
+"""
+            "C.fsi", """
+module C
+
+type CType = class end
+"""
+            "C.fs", """
+module C
+
+type CType = class end
+"""
+            "D.fsi", """
+module D
+
+open A
+open C
+
+val d: CType -> unit 
+"""
+            "D.fs", """
+module D
+
+open A
+open B
+open C
+
+let d (c: CType) =
+    let a : AType = failwith "todo"
+    b a
+"""
+        ]
+        |> FProject.Make  CompileOutput.Library
+    
     let all =
         [
             encodeDecodeSimple
             diamondBroken1
             fsFsi
             emptyNamespace
+            dependentSignatures
         ]
 
 type Case =

--- a/tests/ParallelTypeCheckingTests/Tests/TestDependencyResolution.fs
+++ b/tests/ParallelTypeCheckingTests/Tests/TestDependencyResolution.fs
@@ -264,7 +264,7 @@ let ``Analyse whole projects and print statistics`` (projectFile : string) =
         files
         |> Array.Parallel.mapi (fun i f ->
             let code = System.IO.File.ReadAllText(f)
-            let ast = getParseResults code
+            let ast = parseSourceCode(f, code)
             {
                 Idx = FileIdx.make i
                 //Code = code


### PR DESCRIPTION
Hello,

This resolves the problem that was detected in #10.

I first removed the workaround where a signature file depends on all the signature files that came before it. Surprisingly, I didn't break any unit tests by doing that. This is something to pay closer attention to in the future.
Next, I've added my failing test case. Then I updated the merge code and my test case worked.
From now on I hope to inspire you to do every next change test driven. This would be a good preparation for the eventual draft PR.

Two more pointers I do want to mention:
- Can we start always formatting the code? Because you didn't do this, I'm not able to do it either because it would make a PR diff larger than necessary. (See [ancient greek tragedy](https://fsprojects.github.io/fantomas/docs/end-users/FormattingCheck.html#The-tragedy-of-the-ancient-Greek-developers))
- Please consider abandoning the separate `ParallelTypeCheckingTests.fsproj` project. Your eventual PR will not be merged in using that. It is best to move the bits to the right projects instead.

