### PR TITLE
Use ProjInfo in tests

### DIFF
--- a/FSharp.sln
+++ b/FSharp.sln
@@ -109,6 +109,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "ParallelTypeCheckingTests", "tests\ParallelTypeCheckingTests\ParallelTypeCheckingTests.fsproj", "{59C31D40-97E0-4A69-ABD9-D316BD798ED8}"
 EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "ArgsGenerator", "tests\ArgsGenerator\ArgsGenerator.fsproj", "{90F850DD-52AD-40BC-A497-DE0382C1EE72}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -443,6 +445,18 @@ Global
 		{59C31D40-97E0-4A69-ABD9-D316BD798ED8}.Release|Any CPU.Build.0 = Release|Any CPU
 		{59C31D40-97E0-4A69-ABD9-D316BD798ED8}.Release|x86.ActiveCfg = Release|Any CPU
 		{59C31D40-97E0-4A69-ABD9-D316BD798ED8}.Release|x86.Build.0 = Release|Any CPU
+		{90F850DD-52AD-40BC-A497-DE0382C1EE72}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{90F850DD-52AD-40BC-A497-DE0382C1EE72}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{90F850DD-52AD-40BC-A497-DE0382C1EE72}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{90F850DD-52AD-40BC-A497-DE0382C1EE72}.Debug|x86.Build.0 = Debug|Any CPU
+		{90F850DD-52AD-40BC-A497-DE0382C1EE72}.Proto|Any CPU.ActiveCfg = Debug|Any CPU
+		{90F850DD-52AD-40BC-A497-DE0382C1EE72}.Proto|Any CPU.Build.0 = Debug|Any CPU
+		{90F850DD-52AD-40BC-A497-DE0382C1EE72}.Proto|x86.ActiveCfg = Debug|Any CPU
+		{90F850DD-52AD-40BC-A497-DE0382C1EE72}.Proto|x86.Build.0 = Debug|Any CPU
+		{90F850DD-52AD-40BC-A497-DE0382C1EE72}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{90F850DD-52AD-40BC-A497-DE0382C1EE72}.Release|Any CPU.Build.0 = Release|Any CPU
+		{90F850DD-52AD-40BC-A497-DE0382C1EE72}.Release|x86.ActiveCfg = Release|Any CPU
+		{90F850DD-52AD-40BC-A497-DE0382C1EE72}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -476,6 +490,7 @@ Global
 		{BEC6E796-7E53-4888-AAFC-B8FD55C425DF} = {CE70D631-C5DC-417E-9CDA-B16097BEF1AC}
 		{9C7523BA-7AB2-4604-A5FD-653E82C2BAD1} = {CE70D631-C5DC-417E-9CDA-B16097BEF1AC}
 		{59C31D40-97E0-4A69-ABD9-D316BD798ED8} = {CFE3259A-2D30-4EB0-80D5-E8B5F3D01449}
+		{90F850DD-52AD-40BC-A497-DE0382C1EE72} = {CFE3259A-2D30-4EB0-80D5-E8B5F3D01449}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {BD5177C7-1380-40E7-94D2-7768E1A8B1B8}

--- a/NuGet.config
+++ b/NuGet.config
@@ -15,6 +15,7 @@
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
     <add key="vssdk" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json" />
     <add key="vs-impl" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json" />
+    <add key="NuGet official package source" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />

--- a/src/Compiler/Driver/ParseAndCheckInputs.fs
+++ b/src/Compiler/Driver/ParseAndCheckInputs.fs
@@ -1738,8 +1738,6 @@ let CheckMultipleInputsInParallel
 let mutable CheckMultipleInputsUsingGraphMode: CheckArgs -> (PartialResult list * TcState) =
     fun _ -> failwith $"Graph-based type-checking function not set - set CheckMultipleInputsUsingGraphMode before using this mode"
 
-let mutable typeCheckingMode: TypeCheckingMode = TypeCheckingMode.Sequential
-
 let CheckClosedInputSet (ctok, checkForErrors, tcConfig: TcConfig, tcImports, tcGlobals, prefixPathOpt, tcState, eagerFormat, inputs) =
     // tcEnvAtEndOfLastFile is the environment required by fsi.exe when incrementally adding definitions
     let results, tcState =

--- a/src/Compiler/Driver/ParseAndCheckInputs.fsi
+++ b/src/Compiler/Driver/ParseAndCheckInputs.fsi
@@ -202,8 +202,6 @@ val CheckMultipleInputsFinish:
 /// Finish the checking of a closed set of inputs
 val CheckClosedInputSetFinish: CheckedImplFile list * TcState -> TcState * CheckedImplFile list * ModuleOrNamespace
 
-val mutable typeCheckingMode: TypeCheckingMode
-
 /// Check a closed set of inputs
 val CheckClosedInputSet:
     ctok: CompilationThreadToken *

--- a/tests/ArgsGenerator/ArgsGenerator.fsproj
+++ b/tests/ArgsGenerator/ArgsGenerator.fsproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <OutputType>exe</OutputType>
+        <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <Compile Include="Program.fs" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Ionide.ProjInfo.FCS" Version="0.61.0" />
+        <PackageReference Include="FSharp.Core" Version="6.0.5" />
+        <PackageReference Include="Microsoft.Build.Framework" Version="17.4.0" ExcludeAssets="runtime" />
+        <PackageReference Include="Microsoft.Build.Locator" Version="1.5.5" />
+        <PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.4.0" ExcludeAssets="runtime" />
+        <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.4.0" ExcludeAssets="runtime" />
+    </ItemGroup>
+
+</Project>

--- a/tests/ArgsGenerator/Program.fs
+++ b/tests/ArgsGenerator/Program.fs
@@ -1,0 +1,40 @@
+﻿module ArgsGenerator
+
+open System.IO
+open FSharp.Compiler.CodeAnalysis
+open Ionide.ProjInfo
+
+let optionsToArgs (opts: FSharpProjectOptions) : string[] =
+    Array.append opts.OtherOptions opts.SourceFiles
+
+let loadProjectArgs (projectFile: string) =
+    let dir = Path.GetDirectoryName projectFile
+    let _ = Init.init (DirectoryInfo dir) None
+
+    let props =
+        [
+            "TargetFramework", "net7.0"
+            "Configuration", "Release"
+        ]
+    let res =
+        ProjectLoader.getProjectInfo projectFile props (BinaryLogGeneration.Within(DirectoryInfo("c:/projekty/fsharp/cracking_logs")))
+
+    match res [] with
+    | Result.Ok _res ->
+        let fcs = FCS.mapToFSharpProjectOptions _res []
+        let args = optionsToArgs fcs
+        args
+    | Result.Error err -> failwith $"Failed to crack project: {err}"
+
+/// Given a project file to analyse, generates fsc commandline arguments for compiling it, then saves them to a file.
+[<EntryPoint>]
+let main argv =
+    match argv with
+    | [| projectFile; outputFile |] ->
+        printfn $"Loading project args for project file: {projectFile}"
+        let args = loadProjectArgs projectFile
+        printfn $"Loaded {args.Length} args. Saving them to {outputFile}"
+        File.WriteAllLines(outputFile, args)
+        0
+    | _ ->
+        failwith "Invalid args. Usage: 'ArgsGenerator.exe %project_file% %output_file%'"

--- a/tests/ParallelTypeCheckingTests/ParallelTypeCheckingTests.fsproj
+++ b/tests/ParallelTypeCheckingTests/ParallelTypeCheckingTests.fsproj
@@ -72,8 +72,4 @@
     <PackageReference Include="FSharp.Core" Version="$(FSharpCoreShippedPackageVersionValue)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Buildalyzer" Version="4.1.2" />
-  </ItemGroup>
-
 </Project>

--- a/tests/ParallelTypeCheckingTests/Program.fs
+++ b/tests/ParallelTypeCheckingTests/Program.fs
@@ -1,35 +1,28 @@
 ﻿module internal ParallelTypeCheckingTests.Program
 
-#nowarn "1182"
-
-open FSharp.Compiler.CompilerConfig
 open ParallelTypeCheckingTests.TestUtils
 
-let _parse (argv: string[]) : Args =
-    let parseMode (mode: string) =
-        match mode.ToLower() with
+let parseArgs (argv: string[]) : Args =
+    let parseMode (method: string) =
+        match method.ToLower() with
         | "sequential" -> Method.Sequential
         | "parallelfs" -> Method.ParallelCheckingOfBackedImplFiles
         | "graph" -> Method.Graph
-        | _ -> failwith $"Unrecognised mode: {mode}"
+        | _ -> failwith $"Unrecognised method: {method}"
 
-    let path, mode, workingDir =
+    let method, path =
         match argv with
-        | [| path |] -> path, Method.Sequential, None
-        | [| path; method |] -> path, parseMode method, None
-        | [| path; method; workingDir |] -> path, parseMode method, Some workingDir
-        | _ -> failwith "Invalid args - use 'args_path [method [fs-parallel]]'"
+        | [| path |] -> Method.Graph, path
+        | [| method; path |] -> parseMode method, path
+        | _ -> failwith "Invalid args. Usage: '%method% %project_file%'"
 
     {
-        Path = path
-        LineLimit = None
-        Method = mode
-        WorkingDir = workingDir
+        Method = method
+        ProjectFile = path
     }
 
 [<EntryPoint>]
-let main _argv =
-    let args = _parse _argv
-    let args = { args with LineLimit = None }
+let main argv =
+    let args = parseArgs argv
     TestCompilationFromCmdlineArgs.TestCompilerFromArgs args
     0

--- a/tests/ParallelTypeCheckingTests/Tests/Utils.fs
+++ b/tests/ParallelTypeCheckingTests/Tests/Utils.fs
@@ -1,15 +1,16 @@
 ﻿module ParallelTypeCheckingTests.TestUtils
 
 open System
+open System.IO
 open FSharp.Compiler
 open FSharp.Compiler.CompilerConfig
-open ParallelTypeCheckingTests
 open Xunit
 open FSharp.Test
 open FSharp.Test.Compiler
 open OpenTelemetry
 open OpenTelemetry.Resources
 open OpenTelemetry.Trace
+open System.Diagnostics
 
 let packages =
     // Here we assume that the NuGet packages are located in a certain user folder,
@@ -45,14 +46,13 @@ let setupOtel () =
             c.MaxPayloadSizeInBytes <- Nullable(1000000000))
         .Build()
 
-type internal Args =
-    {
-        Path: string
-        LineLimit: int option
-        Method: Method
-        WorkingDir: string option
-    }
 
+type Args =
+    {
+        Method : Method
+        ProjectFile : string
+    }
+    
 let makeCompilationUnit (files: (string * string) list) : CompilationUnit =
     let files =
         files |> List.map (fun (name, code) -> SourceCodeFileKind.Create(name, code))
@@ -69,9 +69,57 @@ let internal mapMethod (method: Method) =
     | Method.ParallelCheckingOfBackedImplFiles -> TypeCheckingMode.ParallelCheckingOfBackedImplFiles
     | Method.Graph -> TypeCheckingMode.Graph
 
-/// Includes mutation of static config.
-/// A very hacky way to setup the given type-checking method - mutates static state and returns new args
-/// TODO Make the method configurable via proper config passed top-down
-let setupCompilationMethod (method: Method) =
-    let mode = mapMethod method
-    ParseAndCheckInputs.typeCheckingMode <- mode
+let runProcess
+    (name : string)
+    (args : string)
+    workingDir
+    (envVariables : (string * string) list)
+    =
+    let info = ProcessStartInfo ()
+    info.WindowStyle <- ProcessWindowStyle.Hidden
+    info.Arguments <- args
+    info.FileName <- name
+    info.UseShellExecute <- false
+    info.WorkingDirectory <- workingDir
+    info.CreateNoWindow <- true
+
+    envVariables |> List.iter (fun (k, v) -> info.EnvironmentVariables[ k ] <- v)
+
+    printfn $"Running '{name} {args}' in '{workingDir}'"
+    let p = new Process (StartInfo = info)
+    p.EnableRaisingEvents <- true
+    p.Start () |> ignore
+    p.WaitForExit ()
+
+    if p.ExitCode <> 0 then
+        failwith $"Running process '{name} {args}' failed."
+
+let getProjectArgs (projectFile : string) : string[] =
+    // TODO Make ArgsGenerator a dotnet tool
+    let argsGeneratorProjectPath = $"{__SOURCE_DIRECTORY__}/../../ArgsGenerator/ArgsGenerator.fsproj"
+    let workingDir = "."
+    let name = "dotnet.exe" // TODO Handle non-Windows OS
+    let argsFile = Path.GetTempFileName()
+    let envVariables = []
+    
+    // We run the ArgsGenerator project using 'dotnet run', and specify two arguments: project file to analyse, output file.
+    let args =
+        [|
+            "run"
+            "--project"
+            argsGeneratorProjectPath
+            "--"
+            $"\"{projectFile}\""
+            argsFile
+        |]
+        |> fun args -> String.Join(" ", args)
+    
+    runProcess name args workingDir envVariables
+    
+    let output = File.ReadAllLines argsFile
+    output
+
+/// Given FSC arguments, extract those that represent source files
+let extractSourceFilesFromArgs (args: string[]): string[] =
+    args
+    |> Array.filter (fun arg -> arg.StartsWith("-") |> not)


### PR DESCRIPTION
Create ArgsGenerator that uses ProjInfo to dump fsc args in a file, then run it in unit tests.

Not fully working as ProjInfo is missing some necessary args.