### PR TITLE
Pairs

### DIFF
--- a/src/Compiler/Driver/ParseAndCheckInputs.fs
+++ b/src/Compiler/Driver/ParseAndCheckInputs.fs
@@ -1479,7 +1479,8 @@ let CheckOneInputAux'
                 // printfn $"Finished Processing Sig {file.FileName}"
                 return
                     fun isFinalFold tcState ->
-                        // printfn $"Applying Sig {file.FileName}"
+                        printfn $"Applying Sig {file.FileName} (final: {isFinalFold})"
+
                         let fsiPartialResult, tcState =
                             let rootSigs = Zmap.add qualNameOfFile sigFileType tcState.tcsRootSigs
 
@@ -1504,6 +1505,9 @@ let CheckOneInputAux'
                         if isFinalFold then
                             fsiPartialResult, tcState
                         else
+                            // Train of thought: I'm not sure you want to add the results to the tcState,
+                            // when this function is called right before it will check the implementation file.
+
                             // Update the TcEnv of implementation files to also contain the signature data.
                             let _ccuSigForFile, tcState =
                                 AddCheckResultsToTcState

--- a/src/Compiler/Driver/ParseAndCheckInputs.fs
+++ b/src/Compiler/Driver/ParseAndCheckInputs.fs
@@ -1426,7 +1426,7 @@ let CheckOneInputAux'
       tcState: TcState,
       inp: ParsedInput,
       _skipImplIfSigExists: bool): (unit -> bool) * TcConfig * TcImports * TcGlobals * LongIdent option * TcResultsSink * TcState * ParsedInput * bool)
-    : Cancellable<bool -> TcState -> PartialResult * TcState> =
+    : Cancellable<TcState -> PartialResult * TcState> =
 
     cancellable {
         try
@@ -1478,43 +1478,27 @@ let CheckOneInputAux'
 
                 // printfn $"Finished Processing Sig {file.FileName}"
                 return
-                    fun isFinalFold tcState ->
-                        printfn $"Applying Sig {file.FileName} (final: {isFinalFold})"
+                    fun tcState ->
+                        // printfn $"Applying Sig {file.FileName}"
 
-                        let fsiPartialResult, tcState =
-                            let rootSigs = Zmap.add qualNameOfFile sigFileType tcState.tcsRootSigs
+                        let rootSigs = Zmap.add qualNameOfFile sigFileType tcState.tcsRootSigs
 
-                            let tcSigEnv =
-                                AddLocalRootModuleOrNamespace TcResultsSink.NoSink tcGlobals amap m tcState.tcsTcSigEnv sigFileType
+                        let tcSigEnv =
+                            AddLocalRootModuleOrNamespace TcResultsSink.NoSink tcGlobals amap m tcState.tcsTcSigEnv sigFileType
 
-                            // Add the signature to the signature env (unless it had an explicit signature)
-                            let ccuSigForFile = CombineCcuContentFragments [ sigFileType; tcState.tcsCcuSig ]
+                        // Add the signature to the signature env (unless it had an explicit signature)
+                        let ccuSigForFile = CombineCcuContentFragments [ sigFileType; tcState.tcsCcuSig ]
 
-                            let partialResult = tcEnv, EmptyTopAttrs, None, ccuSigForFile
+                        let partialResult = tcEnv, EmptyTopAttrs, None, ccuSigForFile
 
-                            let tcState =
-                                { tcState with
-                                    tcsTcSigEnv = tcSigEnv
-                                    tcsRootSigs = rootSigs
-                                    tcsCreatesGeneratedProvidedTypes =
-                                        tcState.tcsCreatesGeneratedProvidedTypes || createsGeneratedProvidedTypes
-                                }
+                        let tcState =
+                            { tcState with
+                                tcsTcSigEnv = tcSigEnv
+                                tcsRootSigs = rootSigs
+                                tcsCreatesGeneratedProvidedTypes = tcState.tcsCreatesGeneratedProvidedTypes || createsGeneratedProvidedTypes
+                            }
 
-                            partialResult, tcState
-
-                        if isFinalFold then
-                            fsiPartialResult, tcState
-                        else
-                            // Train of thought: I'm not sure you want to add the results to the tcState,
-                            // when this function is called right before it will check the implementation file.
-
-                            // Update the TcEnv of implementation files to also contain the signature data.
-                            let _ccuSigForFile, tcState =
-                                AddCheckResultsToTcState
-                                    (tcGlobals, amap, true, prefixPathOpt, tcSink, tcState.tcsTcImplEnv, qualNameOfFile, sigFileType)
-                                    tcState
-
-                            fsiPartialResult, tcState
+                        partialResult, tcState
 
             | ParsedInput.ImplFile file ->
                 // printfn $"Processing Impl {file.FileName}"
@@ -1543,45 +1527,34 @@ let CheckOneInputAux'
 
                 // printfn $"Finished Processing Impl {file.FileName}"
                 return
-                    fun isFinalFold tcState ->
-                        let addResultToState () =
-                            // Check if we've already seen an implementation for this fragment
-                            if Zset.contains qualNameOfFile tcState.tcsRootImpls then
-                                errorR (Error(FSComp.SR.buildImplementationAlreadyGiven (qualNameOfFile.Text), m))
+                    fun tcState ->
+                        // Check if we've already seen an implementation for this fragment
+                        if Zset.contains qualNameOfFile tcState.tcsRootImpls then
+                            errorR (Error(FSComp.SR.buildImplementationAlreadyGiven (qualNameOfFile.Text), m))
 
-                            // printfn $"Applying Impl Backed={backed} {file.FileName}"
-                            let ccuSigForFile, fsTcState =
-                                AddCheckResultsToTcState
-                                    (tcGlobals, amap, false, prefixPathOpt, tcSink, tcState.tcsTcImplEnv, qualNameOfFile, implFile.Signature)
-                                    tcState
+                        // printfn $"Applying Impl Backed={backed} {file.FileName}"
+                        let ccuSigForFile, fsTcState =
+                            AddCheckResultsToTcState
+                                (tcGlobals, amap, false, prefixPathOpt, tcSink, tcState.tcsTcImplEnv, qualNameOfFile, implFile.Signature)
+                                tcState
 
-                            // backed impl files must not add results as there are already results from .fsi files
-                            //let fsTcState = if backed then tcState else fsTcState
+                        // backed impl files must not add results as there are already results from .fsi files
+                        //let fsTcState = if backed then tcState else fsTcState
 
-                            let partialResult = tcEnvAtEnd, topAttrs, Some implFile, ccuSigForFile
+                        let partialResult = tcEnvAtEnd, topAttrs, Some implFile, ccuSigForFile
 
-                            let tcState =
-                                { fsTcState with
-                                    tcsCreatesGeneratedProvidedTypes =
-                                        fsTcState.tcsCreatesGeneratedProvidedTypes || createsGeneratedProvidedTypes
-                                }
+                        let tcState =
+                            { fsTcState with
+                                tcsCreatesGeneratedProvidedTypes =
+                                    fsTcState.tcsCreatesGeneratedProvidedTypes || createsGeneratedProvidedTypes
+                            }
 
-                            // printfn $"Finished applying Impl {file.FileName}"
-                            partialResult, tcState
-
-                        match rootSigOpt with
-                        | None -> addResultToState ()
-                        | Some _ when isFinalFold -> addResultToState ()
-                        | Some rootSig ->
-                            // In this case, we are skipping the step where we add the results of the implementation file to the tcState.
-                            // The fold function of a signature file will add the result (of the signature),
-                            // to the implementation when it is not processing the final fold.
-                            let partialResult = tcEnvAtEnd, topAttrs, Some implFile, rootSig
-                            partialResult, tcState
+                        // printfn $"Finished applying Impl {file.FileName}"
+                        partialResult, tcState
 
         with e ->
             errorRecovery e range0
-            return fun _ tcState -> (tcState.TcEnvFromSignatures, EmptyTopAttrs, None, tcState.tcsCcuSig), tcState
+            return fun tcState -> (tcState.TcEnvFromSignatures, EmptyTopAttrs, None, tcState.tcsCcuSig), tcState
     }
 
 /// Typecheck a single file (or interactive entry into F# Interactive). If skipImplIfSigExists is set to true
@@ -1596,8 +1569,30 @@ let CheckOneInput'
       tcState: TcState,
       input: ParsedInput,
       skipImplIfSigExists: bool): (unit -> bool) * TcConfig * TcImports * TcGlobals * LongIdent option * TcResultsSink * TcState * ParsedInput * bool)
-    : Cancellable<bool -> TcState -> PartialResult * TcState> =
+    : Cancellable<TcState -> PartialResult * TcState> =
     CheckOneInputAux'(checkForErrors, tcConfig, tcImports, tcGlobals, prefixPathOpt, tcSink, tcState, input, skipImplIfSigExists)
+
+let AddSignatureResultToTcImplEnv (tcImports: TcImports, tcGlobals, prefixPathOpt, tcSink, tcState, input: ParsedInput) =
+    let qualNameOfFile = input.QualifiedName
+    let rootSigOpt = tcState.tcsRootSigs.TryFind qualNameOfFile
+
+    match rootSigOpt with
+    | None -> failwithf $"No signature data was found for %s{input.FileName}"
+    | Some rootSig ->
+        fun (tcState: TcState) ->
+            let amap = tcImports.GetImportMap()
+
+            // Add the results of type checking the signature file to the TcEnv of implementation files.
+            let ccuSigForFile, tcState =
+                AddCheckResultsToTcState
+                    (tcGlobals, amap, true, prefixPathOpt, tcSink, tcState.tcsTcImplEnv, qualNameOfFile, rootSig)
+                    tcState
+
+            // This partial result will be discarded in the end of the graph resolution.
+            let partialResult: PartialResult =
+                tcState.tcsTcSigEnv, EmptyTopAttrs, None, ccuSigForFile
+
+            partialResult, tcState
 
 // Within a file, equip loggers to locally filter w.r.t. scope pragmas in each input
 let DiagnosticsLoggerForInput (tcConfig: TcConfig, input: ParsedInput, oldLogger) =

--- a/src/Compiler/Driver/ParseAndCheckInputs.fsi
+++ b/src/Compiler/Driver/ParseAndCheckInputs.fsi
@@ -185,7 +185,16 @@ val CheckOneInput':
     tcState: TcState *
     input: ParsedInput *
     skipImplIfSigExists: bool ->
-        Cancellable<bool -> TcState -> PartialResult * TcState>
+        Cancellable<TcState -> PartialResult * TcState>
+
+val AddSignatureResultToTcImplEnv:
+    tcImports: TcImports *
+    tcGlobals: TcGlobals *
+    prefixPathOpt: LongIdent option *
+    tcSink: NameResolution.TcResultsSink *
+    tcState: TcState *
+    input: ParsedInput ->
+        (TcState -> PartialResult * TcState)
 
 val CheckMultipleInputsInParallel:
     (CompilationThreadToken * (unit -> bool) * TcConfig * TcImports * TcGlobals * LongIdent option * TcState * (PhasedDiagnostic -> PhasedDiagnostic) * ParsedInput list) ->

--- a/tests/ParallelTypeCheckingTests/Code/GraphProcessing.fs
+++ b/tests/ParallelTypeCheckingTests/Code/GraphProcessing.fs
@@ -40,6 +40,7 @@ type ProcessedNode<'Item, 'Result> =
 let processGraph<'Item, 'Result when 'Item: equality and 'Item: comparison>
     (graph: Graph<'Item>)
     (work: ('Item -> ProcessedNode<'Item, 'Result>) -> NodeInfo<'Item> -> 'Result)
+    (includeInFinalState: 'Item -> bool)
     (ct: CancellationToken)
     : ('Item * 'Result)[] =
     let transitiveDeps = graph |> Graph.transitiveOpt
@@ -125,6 +126,7 @@ let processGraph<'Item, 'Result when 'Item: equality and 'Item: comparison>
     waitHandle.WaitOne() |> ignore
 
     nodes.Values
+    |> Seq.filter (fun node -> includeInFinalState node.Info.Item)
     |> Seq.map (fun node ->
         let result =
             node.Result

--- a/tests/ParallelTypeCheckingTests/Code/ParallelTypeChecking.fs
+++ b/tests/ParallelTypeCheckingTests/Code/ParallelTypeChecking.fs
@@ -27,12 +27,17 @@ let DiagnosticsLoggerForInput (tcConfig: TcConfig, input: ParsedInput, oldLogger
 
 type State = TcState * bool
 type FinalFileResult = TcEnv * TopAttribs * CheckedImplFile option * ModuleOrNamespaceType
-type SingleResult = bool -> State -> FinalFileResult * State
+type SingleResult = State -> FinalFileResult * State
 type Item = File
 
 type PartialResult = TcEnv * TopAttribs * CheckedImplFile option * ModuleOrNamespaceType
 
-let folder (isFinalFold: bool) (state: State) (result: SingleResult) : FinalFileResult * State = result isFinalFold state
+let folder (state: State) (result: SingleResult) : FinalFileResult * State = result state
+
+[<RequireQualifiedAccess>]
+type Dependency =
+    | PhysicalFile of fileIndex: int
+    | Pair of signatureFileIndex: int
 
 /// Use parallel checking of implementation files that have signature files
 let CheckMultipleInputsInParallel
@@ -51,7 +56,67 @@ let CheckMultipleInputsInParallel
                 AST = input
             })
 
-    let graph = DependencyResolution.mkGraph sourceFiles
+    let filePairs = FilePairMap(sourceFiles)
+    let graph = DependencyResolution.mkGraph filePairs sourceFiles
+
+    // TcState has two typing environments: TcEnvFromSignatures && TcEnvFromImpls
+    // When type checking a file, depending on the type (implementation or signature), it will use one of these typing environments (TcEnv).
+    // Checking a file will populate the respective TcEnv.
+    //
+    // When a file has a dependencies, the information of the signature file in case a pair (1) will suffice to type-check the file.
+    // Example: if `B.fs` has a dependency on `A`, the information of `A.fsi` is enough for `B.fs` to type-check,
+    // on condition that it is available in the TcEnvFromImpls.
+    // We introduce a special Pair dependency node in the graph to satisfy this. `B.fs -> [ A.fsi ]` becomes `B.fs -> [ Pair<A> ].
+    // The `Pair<A>` node will duplicate the signature information which A.fsi provided.
+    // Processing a Pair will add the information from the TcEnvFromSignatures to the TcEnvFromImpls.
+    // This means `A` will be known in both TcEnvs and therefor `B.fs` can be type-checked.
+    // By doing this, we can speed up the graph processing as type checking a signature file is less expensive than its implementation counterpart.
+    //
+    // When we need to actually type-check the implementation file of a Pair, we cannot have the duplicate information of the signature file present in TcEnvFromImpls.
+    // Example `A.fs -> [ A.fsi ]`, because an implementation file always depends on its signature.
+    // Type-checking `A.fs` will add the actual information to TcEnvFromImpls and we do not depend on the Pair<A> for `A.fs` itself.
+    //
+    // In order to deal correctly with the Pair logic, we need to transform the resolved graph to contain the additional pair nodes.
+    // After we have type-checked the graph, we exclude the Pair nodes as they are not actual physical files in our project.
+    //
+    // (1) : A pair is consider the combination of a implementation and signature file. (For example `A.fsi` and matching `A.fs` is Pair<A>)
+    let dependencyGraph =
+        let mkPair n = Dependency.Pair n
+        let mkPhysicalFile n = Dependency.PhysicalFile n
+
+        // Map any signature dependencies to the Pair counterparts.
+        // Unless, the signature dependency is the backing file of the current (implementation) file.
+        let mapDependencies idx deps =
+            Array.map
+                (fun dep ->
+                    if filePairs.IsSignature dep then
+                        let implIdx = filePairs.GetImplementationIndex dep
+
+                        if implIdx = idx then
+                            // This is the matching signature for the implementation
+                            // Keep using the physical file
+                            mkPhysicalFile dep
+                        else
+                            mkPair dep
+                    else
+                        mkPhysicalFile dep)
+                deps
+
+        // Transform the graph to include Pair nodes when necessary.
+        graph
+        |> Seq.collect (fun (KeyValue (fileIdx, deps)) ->
+            if filePairs.IsSignature fileIdx then
+                // Add an additional Pair node for the signature file.
+                [|
+                    // Mark the current file as physical and map the dependencies.
+                    mkPhysicalFile fileIdx, mapDependencies fileIdx deps
+                    // Introduce a new node that depends on the signature.
+                    mkPair fileIdx, [| mkPhysicalFile fileIdx |]
+                |]
+            else
+                [| mkPhysicalFile fileIdx, mapDependencies fileIdx deps |])
+        |> Graph.make
+
     // graph |> Graph.map (fun idx -> sourceFiles.[idx].File) |> Graph.print
 
     // let graphDumpPath =
@@ -75,10 +140,23 @@ let CheckMultipleInputsInParallel
 
     let mutable cnt = 1
 
+    let processPair (input: ParsedInput) ((currentTcState, _currentPriorErrors): State) : State -> PartialResult * State =
+        fun (state: State) ->
+            let tcState, currentPriorErrors = state
+
+            let f =
+                // Retrieve the type-checked signature information and add it to the TcEnvFromImpls.
+                AddSignatureResultToTcImplEnv(tcImports, tcGlobals, prefixPathOpt, TcResultsSink.NoSink, currentTcState, input)
+
+            // The `partialResult` will be excluded at the end of `GraphProcessing.processGraph`.
+            // The important thing is that `nextTcState` will populated the necessary information to TcEnvFromImpls.
+            let partialResult, nextTcState = f tcState
+            partialResult, (nextTcState, currentPriorErrors)
+
     let processFile
         ((input, logger): ParsedInput * DiagnosticsLogger)
         ((currentTcState, _currentPriorErrors): State)
-        : bool -> State -> PartialResult * State =
+        : State -> PartialResult * State =
         cancellable {
             use _ = UseDiagnosticsLogger logger
             // TODO Is it OK that we don't update 'priorErrors' after processing batches?
@@ -89,26 +167,15 @@ let CheckMultipleInputsInParallel
 
             // printfn $"#{c} [thread {Thread.CurrentThread.ManagedThreadId}] Type-checking {input.FileName}"
 
-            let! f =
-                CheckOneInput'(
-                    checkForErrors2,
-                    tcConfig,
-                    tcImports,
-                    tcGlobals,
-                    prefixPathOpt,
-                    tcSink,
-                    currentTcState,
-                    input,
-                    false // skipImpFiles...
-                )
+            let! f = CheckOneInput'(checkForErrors2, tcConfig, tcImports, tcGlobals, prefixPathOpt, tcSink, currentTcState, input, false)
 
             // printfn $"Finished Processing AST {file.ToString()}"
             return
-                (fun (isFinalFold: bool) (state: State) ->
+                (fun (state: State) ->
 
                     // printfn $"Applying {file.ToString()}"
                     let tcState, priorErrors = state
-                    let (partialResult: PartialResult, tcState) = f isFinalFold tcState
+                    let (partialResult: PartialResult, tcState) = f tcState
 
                     let hasErrors = logger.ErrorCount > 0
                     // TODO Should we use local _priorErrors or global priorErrors?
@@ -128,14 +195,27 @@ let CheckMultipleInputsInParallel
                 let logger = DiagnosticsLoggerForInput(tcConfig, input, oldLogger)
                 input, logger)
 
-        let processFile (fileIdx: int) (state: State) : bool -> State -> PartialResult * State =
-            let parsedInput, logger = inputsWithLoggers[fileIdx]
-            processFile (parsedInput, logger) state
+        let processFile (dependency: Dependency) (state: State) : State -> PartialResult * State =
+            match dependency with
+            | Dependency.Pair idx ->
+                let parsedInput, _ = inputsWithLoggers.[idx]
+                processPair parsedInput state
+            | Dependency.PhysicalFile idx ->
+                let parsedInput, logger = inputsWithLoggers.[idx]
+                processFile (parsedInput, logger) state
 
         let state: State = tcState, priorErrors
 
         let partialResults, (tcState, _) =
-            TypeCheckingGraphProcessing.processFileGraph<int, State, SingleResult, FinalFileResult> graph processFile folder state cts.Token
+            TypeCheckingGraphProcessing.processFileGraph<Dependency, State, SingleResult, FinalFileResult>
+                dependencyGraph
+                processFile
+                folder
+                (function
+                | Dependency.Pair _ -> false
+                | Dependency.PhysicalFile _ -> true)
+                state
+                cts.Token
 
         let partialResults =
             partialResults |> Array.sortBy fst |> Array.map snd |> Array.toList

--- a/tests/ParallelTypeCheckingTests/Tests/DependencyResolutionTests.fs
+++ b/tests/ParallelTypeCheckingTests/Tests/DependencyResolutionTests.fs
@@ -9,7 +9,9 @@ let scenarios = codebases
 
 [<TestCaseSource(nameof scenarios)>]
 let ``Supported scenario`` (scenario: Scenario) =
-    let graph = mkGraph (Array.map (fun f -> f.FileWithAST) scenario.Files)
+    let files = Array.map (fun f -> f.FileWithAST) scenario.Files
+    let filePairs = FilePairMap(files)
+    let graph = mkGraph filePairs files
 
     for file in scenario.Files do
         let expectedDeps = file.ExpectedDependencies

--- a/tests/ParallelTypeCheckingTests/Tests/Scenarios.fs
+++ b/tests/ParallelTypeCheckingTests/Tests/Scenarios.fs
@@ -565,16 +565,17 @@ val Foo: unit -> unit
 """
                     Set.empty
                 sourceFile
-                    "B.fs"
+                    "A.fs"
                     """
-module Barry
+module Bar
 
-type Barry() =
+type Bar() =
     static member Foo () : unit =
         failwith ""
 
 let Foo () : unit = 
-    Barry.Foo ()
+    Bar.Foo ()
 """
                     (set [| 0 |])
+            ]
     ]

--- a/tests/ParallelTypeCheckingTests/Tests/Scenarios.fs
+++ b/tests/ParallelTypeCheckingTests/Tests/Scenarios.fs
@@ -549,4 +549,32 @@ let fn (a: A) = ()
 """
                     (set [| 0 |])
             ]
+        scenario
+            "Implementation uses something defined above and in signature"
+            [
+                sourceFile
+                    "A.fsi"
+                    """
+module Bar
+
+type Bar =
+    new: unit -> Bar
+    static member Foo: unit -> unit
+
+val Foo: unit -> unit
+"""
+                    Set.empty
+                sourceFile
+                    "B.fs"
+                    """
+module Barry
+
+type Barry() =
+    static member Foo () : unit =
+        failwith ""
+
+let Foo () : unit = 
+    Barry.Foo ()
+"""
+                    (set [| 0 |])
     ]

--- a/tests/ParallelTypeCheckingTests/Tests/TestCompilation.fs
+++ b/tests/ParallelTypeCheckingTests/Tests/TestCompilation.fs
@@ -304,6 +304,20 @@ let ``Compile a valid scenario using graph-based type-checking`` (scenario: Scen
         }
 
 [<TestCaseSource(nameof scenarios)>]
+let ``Compile a valid scenario using parallel backed implementation files type-checking`` (scenario: Scenario) =
+    let project =
+        scenario.Files
+        |> Array.map (fun (f: FileInScenario) -> f.FileWithAST.File, f.Content)
+        |> List.ofArray
+        |> FProject.Make CompileOutput.Library
+
+    compileAValidProject
+        {
+            Method = Method.ParallelCheckingOfBackedImplFiles
+            Project = project
+        }
+
+[<TestCaseSource(nameof scenarios)>]
 let ``Compile a valid scenario using sequential type-checking`` (scenario: Scenario) =
     let project =
         scenario.Files

--- a/tests/ParallelTypeCheckingTests/Tests/TypedTreeGraph.fs
+++ b/tests/ParallelTypeCheckingTests/Tests/TypedTreeGraph.fs
@@ -180,7 +180,11 @@ let ``Create Graph from typed tree`` (code: Codebase) =
                     Map.add idx allDeps acc)
 
             let typedTreeMap = collectAllDeps graphFromTypedTree
-            let graphFromHeuristic = files.Values |> Seq.toArray |> DependencyResolution.mkGraph
+
+            let filePairs = files.Values |> Seq.toArray |> FilePairMap
+
+            let graphFromHeuristic =
+                files.Values |> Seq.toArray |> DependencyResolution.mkGraph filePairs
 
             graphFromHeuristic
             |> Graph.map (fun n -> files.[n].File)


### PR DESCRIPTION
Hi @safesparrow, I was able to rework the code to have a new version of the infamous `fsix` approach.
I went with the names `Pair` and `Physical` and transform the resolved graph after `mkGraph`.
This has quite the appeal to me as it is more of an implementation detail isolated from the graph resolution.

I wrote some comments on why we do this, for future readers. Please take a look at this and let me know if it makes sense.
